### PR TITLE
fix: add KongVersion to WriteConfig struct to prevent error

### DIFF
--- a/cmd/collect.go
+++ b/cmd/collect.go
@@ -659,8 +659,9 @@ func getKDD() ([]string, error) {
 					log.Errorf("building Kong dump state: %w", err)
 				}
 				err = file.KongStateToFile(ks, file.WriteConfig{
-					Filename:   ws.Name + "-kong-dump.yaml",
-					FileFormat: file.YAML,
+					KongVersion: summaryInfo.KongVersion,
+					Filename:    ws.Name + "-kong-dump.yaml",
+					FileFormat:  file.YAML,
 				})
 				if err != nil {
 					log.Errorf("building Kong dump file: %w", err)


### PR DESCRIPTION
fix: add KongVersion to WriteConfig struct to prevent file.KongStateToFile error

Without the KongVersion string in the WriteConfig struct, file.KongStateToFile
returns an error, preventing the code that dumps the Postgres config file from
being reached. This fix ensures the KongVersion is set, allowing the config
dump to proceed without errors.