### PR TITLE
feat: add binary builds for Windows and macOS(ARM)

### DIFF
--- a/.github/workflows/build-and-compress.yaml
+++ b/.github/workflows/build-and-compress.yaml
@@ -23,24 +23,27 @@ jobs:
           CGO_ENABLED=0 go build -ldflags="-s -w -extldflags '-static'" -o dct
           CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 go build -ldflags="-s -w -extldflags '-static'" -o dct-darwin-arm64
           CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -ldflags="-s -w -extldflags '-static'" -o dct-linux-arm64
+          CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build -ldflags="-s -w -extldflags '-static'" -o dct-win-amd64.exe
 
       - name: Install UPX
         run: | 
           sudo apt-get update
-           sudo apt-get install upx -y
+          sudo apt-get install upx -y
 
       - name: Compress Binary
         run: | 
           upx --best --lzma ./dct
+          upx --best --lzma dct-darwin-arm64 --force-macos
           upx --best --lzma ./dct-linux-arm64
+          upx --best --lzma ./dct-win-amd64.exe
 
-      - name: Upload Compressed Binary
+      - name: Upload Compressed amd64 Binary
         uses: actions/upload-artifact@v4
         with:
           name: compressed-dct-binary
           path: ./dct
 
-      - name: Upload Compressed Linux Binary
+      - name: Upload Compressed Linux arm64 Binary
         uses: actions/upload-artifact@v4
         with:
           name: compressed-dct-linux-arm64-binary
@@ -51,3 +54,9 @@ jobs:
         with:
           name: compressed-dct-darwin-arm64-binary
           path: ./dct-darwin-arm64
+
+      - name: Upload Compressed Windows Binary
+        uses: actions/upload-artifact@v4
+        with:
+          name: compressed-dct-darwin-arm64-binary
+          path: ./dct-win-amd64.exe


### PR DESCRIPTION
- Updated workflow to include Windows (amd64) binaries
- Added support for macOS ARM (arm64) binaries
- Added support for experimental UPX packing on macOS