### PR TITLE
fix: kubernetes file copy

### DIFF
--- a/cmd/collect.go
+++ b/cmd/collect.go
@@ -1772,7 +1772,8 @@ func RunCommandInPod(
 	}
 
 	// dstFile := container + "-" + strings.Replace(cmd[0]+cmd[1], "/", "-", -1)
-	dstFile := fmt.Sprintf("%s-%s.log", container, namedCmd.Name)
+	sanitizedName := strings.ReplaceAll(namedCmd.Name, "/", "-")
+	dstFile := fmt.Sprintf("%s-%s.log", container, sanitizedName)
 
 	// log.Info("Copying file: ", cmd[1], " to: ", exePath+"/"+dstFile)
 


### PR DESCRIPTION
- fix an issue where the file copy command was not working properly due to restrictions in filenames. The filenames included illegal characters, e.g. "/"